### PR TITLE
Update 6_svms lab for mokapot 0.11 API

### DIFF
--- a/notebooks/6_svms.ipynb
+++ b/notebooks/6_svms.ipynb
@@ -41,7 +41,10 @@
     "sns.set(context=\"notebook\", style=\"ticks\")\n",
     "\n",
     "# An example input file for us to work with:\n",
-    "example_file = \"../data/pin_files/scope2_FP97AC.pin\""
+    "example_file = \"../data/pin_files/scope2_FP97AC.pin\"\n",
+    "\n",
+    "# Where mokapot will write its result files:\n",
+    "output_dir = \"mokapot_output\""
    ]
   },
   {
@@ -119,10 +122,17 @@
     "np.random.seed(42)\n",
     "\n",
     "# Read the PSMs and their features from the example file:\n",
+    "# (read_pin returns a list, with one dataset per input file)\n",
     "psms = mokapot.read_pin(example_file)\n",
     "\n",
-    "# Run the standard Percolator algorithm in mokapot:\n",
-    "results, models = mokapot.brew(psms)"
+    "# Run the standard Percolator algorithm in mokapot. brew() trains the models\n",
+    "# and returns them along with the cross-validated scores for each PSM:\n",
+    "models, scores = mokapot.brew(psms, rng=42)\n",
+    "\n",
+    "# Use those scores to assign confidence estimates (q-values, PEPs, ...):\n",
+    "results = mokapot.assign_confidence(\n",
+    "    psms, scores_list=scores, file_root=\"svm\", dest_dir=output_dir\n",
+    ")[0]"
    ]
   },
   {
@@ -140,8 +150,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First, calculate q-values with the best feature:\n",
-    "best_feature = psms.assign_confidence()"
+    "# First, calculate q-values with the best feature.\n",
+    "# When no scores are passed, assign_confidence ranks PSMs by the single best\n",
+    "# feature, giving us a baseline to compare the trained model against:\n",
+    "best_feature = mokapot.assign_confidence(\n",
+    "    psms, file_root=\"best_feature\", dest_dir=output_dir\n",
+    ")[0]"
    ]
   },
   {
@@ -153,8 +167,8 @@
    "source": [
     "# Create a plot:\n",
     "plt.figure()\n",
-    "best_feature.plot_qvalues(label=\"Best Feature\")\n",
-    "results.plot_qvalues(label=\"mokapot Model\")\n",
+    "best_feature.plot_qvalues(\"psms\", label=\"Best Feature\")\n",
+    "results.plot_qvalues(\"psms\", label=\"mokapot Model\")\n",
     "plt.legend()\n",
     "plt.show()"
    ]
@@ -182,7 +196,10 @@
     "lr_model = mokapot.Model(LogisticRegressionCV(solver=\"liblinear\"))\n",
     "\n",
     "# Use the model within mokapot, replacing the SVM:\n",
-    "lr_results, lr_models = mokapot.brew(psms, lr_model)"
+    "lr_models, lr_scores = mokapot.brew(psms, lr_model, rng=42)\n",
+    "lr_results = mokapot.assign_confidence(\n",
+    "    psms, scores_list=lr_scores, file_root=\"lr\", dest_dir=output_dir\n",
+    ")[0]"
    ]
   },
   {
@@ -204,8 +221,8 @@
    "source": [
     "# Create a plot with the results from both models:\n",
     "plt.figure()\n",
-    "results.plot_qvalues(label=\"SVM\")\n",
-    "lr_results.plot_qvalues(label=\"Logistic Regression\")\n",
+    "results.plot_qvalues(\"psms\", label=\"SVM\")\n",
+    "lr_results.plot_qvalues(\"psms\", label=\"Logistic Regression\")\n",
     "plt.legend()\n",
     "plt.show()"
    ]


### PR DESCRIPTION
## Summary

mokapot 0.11 reworked its API around streaming datasets, which broke the SVM/Percolator lab (`notebooks/6_svms.ipynb`). This updates the notebook to the new API.

## What changed
- `read_pin` now returns a **list** of datasets.
- `brew` returns `(models, scores)` instead of confidence objects; confidence is produced separately by `mokapot.assign_confidence`.
- `plot_qvalues` takes the level (e.g. `"psms"`) explicitly.

The notebook now uses the `brew` → `assign_confidence` flow with a per-call `file_root`/`dest_dir` (so the file-backed `Confidence` results don't clobber each other), and the best-feature baseline uses `assign_confidence` with no scores.

## Verification
Executed end-to-end headless (`jupyter nbconvert --execute`) against mokapot 0.11 — runs with no errors and both q-value plots render.

> Depends on the corresponding mokapot 0.11 API fixes (wfondrie/mokapot#142): optional `read_pin(max_workers=...)`, restored `to_df=`, and `str`/`Path` interchangeability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)